### PR TITLE
Allow timers with zero value.

### DIFF
--- a/src/statful.js
+++ b/src/statful.js
@@ -260,14 +260,14 @@
         timer: function (metricName, metricValue, options) {
             try {
                 logger.debug('Register Timer', metricName, metricValue, options);
-                if (metricName && metricValue) {
+                if (metricName && metricValue >= 0) {
                     options = options || {};
 
                     // Push metrics to queue
                     var item = new this.metricsData(metricName, 'timer', metricValue, options.tags, options.agg, options.aggFreq, options.namespace, options.sampleRate);
                     this.util.addItemToQueue('metrics', item);
                 } else {
-                    logger.error('Undefined metric name/value to register as a timer');
+                    logger.error('Undefined metric name or invalid value to register as a timer');
                 }
             } catch (ex) {
                 logger.error(ex);


### PR DESCRIPTION
Simple change to allow emission of timer metrics with a value of zero.

This is useful for example in a scenario where we're doing RUM and want to track the various stages of a request (e.g. connect, ssl, dns, req, res, etc.) and some of those might take 0 ms, due to for example a previously established connection or cached DNS entries.