### PR TITLE
chore(NO-US): Remove dependencies from bower

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: node_js
 node_js:
   - "4.2.2"
 before_install:
-  - npm install -g grunt-cli bower
+  - npm install -g grunt-cli
 install:
-  - npm install && bower install
+  - npm install
 before_script:
   - grunt test

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -33,8 +33,8 @@ module.exports = function (grunt) {
                 files: {
                     'dist/statful.min.js': [
                         'src/*.js',
-                        'bower_components/usertiming/src/usertiming.js',
-                        'bower_components/js-polyfills/es5.js'
+                        require.resolve('usertiming/src/usertiming.js'),
+                        require.resolve('js-polyfills/es5.js')
                     ]
                 }
             },
@@ -49,8 +49,8 @@ module.exports = function (grunt) {
                 files: {
                     'dist/statful.js': [
                         'src/*.js',
-                        'bower_components/usertiming/src/usertiming.js',
-                        'bower_components/js-polyfills/es5.js'
+                        require.resolve('usertiming/src/usertiming.js'),
+                        require.resolve('js-polyfills/es5.js')
                     ]
                 }
             }

--- a/bower.json
+++ b/bower.json
@@ -13,10 +13,5 @@
     "node_modules",
     "bower_components",
     "tests"
-  ],
-  "dependencies": {},
-  "devDependencies": {
-    "usertiming": "^0.1.8",
-    "js-polyfills": "^0.1.33"
-  }
+  ]
 }

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -11,9 +11,9 @@ module.exports = function (config) {
 
             // list of files / patterns to load in the browser (order matters)
             files: [
-                {pattern: 'bower_components/usertiming/src/usertiming.js', include: true},
-                {pattern: 'bower_components/js-polyfills/es5.js', include: true},
-                {pattern: 'bower_components/js-polyfills/xhr.js', include: true},
+                {pattern: require.resolve('usertiming/src/usertiming.js'), include: true},
+                {pattern: require.resolve('js-polyfills/es5.js'), include: true},
+                {pattern: require.resolve('js-polyfills/xhr.js'), include: true},
                 {pattern: 'src/logger.js', included: true},
                 {pattern: 'src/statful.js', included: true},
                 {pattern: 'src/statful-util.js', included: true},
@@ -67,4 +67,3 @@ module.exports = function (config) {
         }
     );
 };
-

--- a/package.json
+++ b/package.json
@@ -24,10 +24,12 @@
     "grunt-eslint": "^19.0.0",
     "grunt-karma": "^2.0.0",
     "jasmine-core": "^2.6.1",
+    "js-polyfills": "^0.1.33",
     "karma": "^1.6.0",
     "karma-coverage": "^1.1.1",
     "karma-jasmine": "^1.1.0",
     "karma-phantomjs-launcher": "^1.0.4",
-    "load-grunt-tasks": "^3.5.2"
+    "load-grunt-tasks": "^3.5.2",
+    "usertiming": "^0.1.8"
   }
 }


### PR DESCRIPTION
Bower is slowly loosing traction and themselves are now recommending
yarn. In order to avoid future problems we can move the devDependencies
to npm and import them directly from node_modules. We can still keep the
bower.json for legacy reasons and in order to avoid problems with older
installations.